### PR TITLE
Added support for data-ng-app

### DIFF
--- a/extension/src/injected/inspector.js
+++ b/extension/src/injected/inspector.js
@@ -80,7 +80,7 @@
    */
   function bootstrapInspector(){
 
-    _angularInjector = angular.element(document.querySelector('[ng-app]')).injector().get;
+    _angularInjector = angular.element(document.querySelector('[ng-app],[data-ng-app]')).injector().get;
 
     instrumentDigest();
     initWatcherCount();


### PR DESCRIPTION
Hi. Thanks for a great app! It is exactly what I have been looking for.

It fails to correctly bootstrap on a site that uses `data-ng-app` instead of `ng-app`. This is also a valid way of doing it as per the  [Angular docs](https://docs.angularjs.org/guide/directive#normalization). 

> Best Practice: Prefer using the dash-delimited format (e.g. ng-bind for ngBind). If you want to use an HTML validating tool, you can instead use the data-prefixed version (e.g. data-ng-bind for ngBind). The other forms shown above are accepted for legacy reasons but we advise you to avoid them.

Adding the data-ng-app an alternative selector make everything work perfectly for me and I'm sure it'll be helpful to some other users.

Thanks.

R
