### PR TITLE
Update inspector.js

### DIFF
--- a/extension/src/injected/inspector.js
+++ b/extension/src/injected/inspector.js
@@ -21,9 +21,11 @@
     };
 
   if (document.readyState === 'complete'){
-    detectAngular();
+    setTimeout(detectAngular, 0);
   } else {
-    window.onload(detectAngular)
+    window.onload(function() {
+     setTimeout(detectAngular, 0);
+    });
   }
 
   /**


### PR DESCRIPTION
Fix: Uncaught TypeError: Cannot read property 'get' of undefined

This patch fixes a code when extension tries to initialize before angular is initialized and got exception:
Uncaught TypeError: Cannot read property 'get' of undefinedbootstrapInspector @ inspector.js:83detectAngular @ inspector.js:74(anonymous function) @ inspector.js:24(anonymous function) @ inspector.js:467
